### PR TITLE
fix: latestUpdates title

### DIFF
--- a/utils/fetch/fetchLatestUpdates.ts
+++ b/utils/fetch/fetchLatestUpdates.ts
@@ -29,7 +29,7 @@ export const fetchLatestUpdates = unstable_cache(
           break;
         }
         const title = (await element.$eval(
-          "a:nth-of-type(2) > div > span",
+          "a:nth-of-type(2) > div > div",
           (el) => el.textContent,
         ))!;
 


### PR DESCRIPTION
fixed the issue of latestUpdates displaying the chapter instead of the title of the manga