### PR TITLE
feat: browserless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,27 +19,11 @@ ENV BROWSERLESS_URL=${BROWSERLESS_URL}
 
 # Set up build environment
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-ENV NODE_ENV=build-local
+ENV BUILD_ENV=build-local
 
 # Install Chromium and dependencies
 RUN apt-get update && apt-get install -y \
     chromium \
-    ca-certificates \
-    fonts-liberation \
-    libasound2 \
-    libatk-bridge2.0-0 \
-    libatk1.0-0 \
-    libcups2 \
-    libdbus-1-3 \
-    libdrm2 \
-    libgtk-3-0 \
-    libnspr4 \
-    libnss3 \
-    libx11-xcb1 \
-    libxcomposite1 \
-    libxdamage1 \
-    libxrandr2 \
-    xdg-utils \
     --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
 
@@ -54,12 +38,14 @@ COPY . .
 
 # Build the application
 RUN npx prisma generate
+RUN apt-get update && apt-get install -y openssl && rm -rf /var/lib/apt/lists/*
 RUN npm run build
 
 # Production stage
 FROM node:23-slim AS runner
 
 WORKDIR /app
+RUN apt-get update && apt-get install -y openssl && rm -rf /var/lib/apt/lists/*
 
 # Copy only necessary files from builder
 COPY --from=builder /app/next.config.ts ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,50 @@
 # Build stage
 FROM node:23-slim AS builder
 
-# Set up build environment
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-
-RUN apt-get update && apt-get install gnupg wget -y && \
-    wget --quiet --output-document=- https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor > /etc/apt/trusted.gpg.d/google-archive.gpg && \
-    sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' && \
-    apt-get update && \
-    apt-get install google-chrome-stable -y --no-install-recommends && \
-    rm -rf /var/lib/apt/lists/*
-
-# Verify that Chrome is installed at the expected location
-RUN ls -alh /usr/bin/google-chrome-stable && \
-    /usr/bin/google-chrome-stable --version
-
-# Set Chrome executable path for Puppeteer
-ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable
-
 WORKDIR /app
 COPY package*.json ./
 COPY prisma ./prisma/
 
 ARG DATABASE_URL
 ENV DATABASE_URL=${DATABASE_URL}
+
+ARG SESSION_SECRET
+ENV SESSION_SECRET=${SESSION_SECRET}
+
+ARG UPLOADTHING_TOKEN
+ENV UPLOADTHING_TOKEN=${UPLOADTHING_TOKEN}
+
+ARG BROWSERLESS_URL
+ENV BROWSERLESS_URL=${BROWSERLESS_URL}
+
+# Set up build environment
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV NODE_ENV=build-local
+
+# Install Chromium and dependencies
+RUN apt-get update && apt-get install -y \
+    chromium \
+    ca-certificates \
+    fonts-liberation \
+    libasound2 \
+    libatk-bridge2.0-0 \
+    libatk1.0-0 \
+    libcups2 \
+    libdbus-1-3 \
+    libdrm2 \
+    libgtk-3-0 \
+    libnspr4 \
+    libnss3 \
+    libx11-xcb1 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxrandr2 \
+    xdg-utils \
+    --no-install-recommends && \
+    rm -rf /var/lib/apt/lists/*
+
+# Puppeteer expects Chrome/Chromium at a known path
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
 
 # Install dependencies
 RUN npm install
@@ -38,23 +59,6 @@ RUN npm run build
 # Production stage
 FROM node:23-slim AS runner
 
-# Install only the needed Chrome dependencies
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-
-RUN apt-get update && apt-get install gnupg wget -y && \
-    wget --quiet --output-document=- https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor > /etc/apt/trusted.gpg.d/google-archive.gpg && \
-    sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' && \
-    apt-get update && \
-    apt-get install google-chrome-stable -y --no-install-recommends && \
-    rm -rf /var/lib/apt/lists/*
-
-# Verify that Chrome is installed at the expected location
-RUN ls -alh /usr/bin/google-chrome-stable && \
-    /usr/bin/google-chrome-stable --version
-
-# Set Chrome executable path for Puppeteer
-ENV PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome-stable
-
 WORKDIR /app
 
 # Copy only necessary files from builder
@@ -64,12 +68,8 @@ COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/prisma ./prisma
 
-ENV DATABASE_URL=""
 ENV SESSION_SECRET=""
 ENV UPLOADTHING_TOKEN=""
-
-# Install only production dependencies
-RUN npm install --omit=dev
 
 EXPOSE 3000
 

--- a/components/lib/ReloadDataButton.tsx
+++ b/components/lib/ReloadDataButton.tsx
@@ -5,18 +5,23 @@ import toast from "react-hot-toast";
 import { useState } from "react";
 import useToastTheme from "@/hooks/useToastTheme";
 
-const ReloadDataButton = ({ tag, tags }: { tag?: string; tags?: string[] }) => {
+const ReloadDataButton = ({
+  tag,
+  tags,
+}: { tag: string; tags?: never } | { tag?: never; tags: string[] }) => {
   const toastOptions = useToastTheme();
   const [isLoading, setIsLoading] = useState(false);
 
   const handleRevalidate = async () => {
     setIsLoading(true);
+
     if (tag) {
       const error = await revalidateTagAction(tag);
       if (error) {
         toast.error(error, toastOptions);
       }
     }
+
     if (tags) {
       for (const tag of tags) {
         const error = await revalidateTagAction(tag);
@@ -25,8 +30,10 @@ const ReloadDataButton = ({ tag, tags }: { tag?: string; tags?: string[] }) => {
         }
       }
     }
+
     setIsLoading(false);
   };
+
   return (
     <div className="flex w-full items-center justify-center">
       <BasicButton onClick={handleRevalidate} disabled={isLoading}>

--- a/components/search-page/ResultList.tsx
+++ b/components/search-page/ResultList.tsx
@@ -1,13 +1,10 @@
 import ResultMainElement from "./ResultMainElement";
 import { fetchSearchMangaResults } from "@/utils/fetch/fetchSearchMangaResults";
-import { notFound } from "next/navigation";
 
 export const ResultList = async ({ mangaName }: { mangaName: string }) => {
   const searchResults = await fetchSearchMangaResults(mangaName);
 
-  if (!searchResults) notFound();
-
-  if (searchResults.length === 0) {
+  if (!searchResults || searchResults.length === 0) {
     return (
       <div className="flex w-[100%] flex-col items-center justify-center gap-4 text-2xl">
         <p>No result found for {mangaName}</p>

--- a/components/search-page/ResultList.tsx
+++ b/components/search-page/ResultList.tsx
@@ -4,7 +4,7 @@ import { fetchSearchMangaResults } from "@/utils/fetch/fetchSearchMangaResults";
 export const ResultList = async ({ mangaName }: { mangaName: string }) => {
   const searchResults = await fetchSearchMangaResults(mangaName);
 
-  if (!searchResults || searchResults.length === 0) {
+  if (searchResults.length === 0) {
     return (
       <div className="flex w-[100%] flex-col items-center justify-center gap-4 text-2xl">
         <p>No result found for {mangaName}</p>

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,9 +1,34 @@
 services:
-  database:
-    image: prismagraphql/mongo-single-replica:4.4.3-bionic
-    environment:
-      MONGO_INITDB_ROOT_USERNAME: root
-      MONGO_INITDB_ROOT_PASSWORD: password
-      INIT_WAIT_SEC: 3
+  mangaxr-browserless:
+    build: .
     ports:
-      - 27017:27017
+      - "127.0.0.1:3000:3000"
+    env_file:
+      - .env
+      - .env.local
+    environment:
+      - DATABASE_URL
+      - SESSION_SECRET
+      - UPLOADTHING_TOKEN
+      - BROWSERLESS_URL
+    depends_on:
+      - browserless
+    container_name: manga-xr-browserless
+    networks:
+      - manga-network
+
+  browserless:
+    image: browserless/chrome
+    ports:
+      - "127.0.0.1:3001:3000"
+    environment:
+      - DEFAULT_BLOCK_ADS=true
+      - MAX_CONCURRENT_SESSIONS=5
+      - PREBOOT_CHROME=true
+    container_name: browserless
+    networks:
+      - manga-network
+
+networks:
+  manga-network:
+    driver: bridge

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -24,8 +24,7 @@ const decrypt = async (session: string | undefined = "") => {
       algorithms: ["HS256"],
     });
     return payload;
-  } catch (error) {
-    console.error(error);
+  } catch {
     return;
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manga-xr",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "private": "false",
   "scripts": {
     "dev": "next dev --turbopack",

--- a/prisma/schema/main.prisma
+++ b/prisma/schema/main.prisma
@@ -1,7 +1,7 @@
 generator client {
     provider        = "prisma-client-js"
     previewFeatures = ["prismaSchemaFolder"]
-    binaryTargets   = ["native", "debian-openssl-3.0.x"]
+    binaryTargets   = ["native", "debian-openssl-3.0.x", "debian-openssl-1.1.x"]
 }
 
 datasource db {

--- a/tests/utils/initBrowser.test.ts
+++ b/tests/utils/initBrowser.test.ts
@@ -9,34 +9,20 @@ describe("initBrowser", () => {
 
   beforeEach(() => {
     vi.resetAllMocks();
-    puppeteer.launch = mockLaunch;
+    puppeteer.connect = mockLaunch;
   });
 
   afterEach(() => {
     vi.unstubAllEnvs();
   });
 
-  it("should launch browser with default options in development", async () => {
-    vi.stubEnv("NODE_ENV", "development");
-    await initBrowser();
-    expect(mockLaunch).toHaveBeenCalledWith(undefined);
-  });
+  it("should launch browser with default browserWSEndpoint in dev and prod", async () => {
+    vi.stubEnv("BROWSERLESS_URL", "ws://localhost:3001");
 
-  it("should launch browser with specific options in production", async () => {
-    vi.stubEnv("NODE_ENV", "production");
     await initBrowser();
+
     expect(mockLaunch).toHaveBeenCalledWith({
-      headless: true,
-      executablePath: "/usr/bin/google-chrome-stable",
-      args: [
-        "--no-sandbox",
-        "--no-zygote",
-        "--disable-setuid-sandbox",
-        "--disable-dev-shm-usage",
-        "--disable-accelerated-2d-canvas",
-        "--disable-gpu",
-        "--disable-software-rasterizer",
-      ],
+      browserWSEndpoint: "ws://localhost:3001",
     });
   });
 

--- a/tests/utils/initBrowser.test.ts
+++ b/tests/utils/initBrowser.test.ts
@@ -29,7 +29,7 @@ describe("initBrowser", () => {
   });
 
   it("should use chromium in build time", async () => {
-    vi.stubEnv("NODE_ENV", "build-local");
+    vi.stubEnv("BUILD_ENV", "build-local");
 
     await initBrowser();
 

--- a/tests/utils/initBrowser.test.ts
+++ b/tests/utils/initBrowser.test.ts
@@ -5,24 +5,46 @@ import puppeteer from "puppeteer";
 vi.mock("puppeteer");
 
 describe("initBrowser", () => {
+  const mockConnect = vi.fn();
   const mockLaunch = vi.fn();
 
   beforeEach(() => {
     vi.resetAllMocks();
-    puppeteer.connect = mockLaunch;
+    puppeteer.connect = mockConnect;
+    puppeteer.launch = mockLaunch;
   });
 
   afterEach(() => {
     vi.unstubAllEnvs();
   });
 
-  it("should launch browser with default browserWSEndpoint in dev and prod", async () => {
-    vi.stubEnv("BROWSERLESS_URL", "ws://localhost:3001");
+  it("should launch browser with default browserWSEndpoint in build time", async () => {
+    vi.stubEnv("BROWSERLESS_URL", "ws://localhost:3000");
+
+    await initBrowser();
+
+    expect(mockConnect).toHaveBeenCalledWith({
+      browserWSEndpoint: "ws://localhost:3000",
+    });
+  });
+
+  it("should launch browser with default browserWSEndpoint in build time", async () => {
+    vi.stubEnv("NODE_ENV", "build-local");
 
     await initBrowser();
 
     expect(mockLaunch).toHaveBeenCalledWith({
-      browserWSEndpoint: "ws://localhost:3001",
+      executablePath: "/usr/bin/chromium",
+      headless: true,
+      args: [
+        "--no-sandbox",
+        "--no-zygote",
+        "--disable-setuid-sandbox",
+        "--disable-dev-shm-usage",
+        "--disable-accelerated-2d-canvas",
+        "--disable-gpu",
+        "--disable-software-rasterizer",
+      ],
     });
   });
 

--- a/tests/utils/initBrowser.test.ts
+++ b/tests/utils/initBrowser.test.ts
@@ -18,17 +18,17 @@ describe("initBrowser", () => {
     vi.unstubAllEnvs();
   });
 
-  it("should launch browser with default browserWSEndpoint in build time", async () => {
-    vi.stubEnv("BROWSERLESS_URL", "ws://localhost:3000");
+  it("should connect to the local browser in development", async () => {
+    vi.stubEnv("NODE_ENV", "development");
 
     await initBrowser();
 
-    expect(mockConnect).toHaveBeenCalledWith({
-      browserWSEndpoint: "ws://localhost:3000",
+    expect(mockLaunch).toHaveBeenCalledWith({
+      args: ["--no-sandbox"],
     });
   });
 
-  it("should launch browser with default browserWSEndpoint in build time", async () => {
+  it("should use chromium in build time", async () => {
     vi.stubEnv("NODE_ENV", "build-local");
 
     await initBrowser();
@@ -45,6 +45,16 @@ describe("initBrowser", () => {
         "--disable-gpu",
         "--disable-software-rasterizer",
       ],
+    });
+  });
+
+  it("should launch browser with default browserWSEndpoint in run time", async () => {
+    vi.stubEnv("BROWSERLESS_URL", "ws://localhost:3000");
+
+    await initBrowser();
+
+    expect(mockConnect).toHaveBeenCalledWith({
+      browserWSEndpoint: "ws://localhost:3000",
     });
   });
 

--- a/utils/closeBrowser.ts
+++ b/utils/closeBrowser.ts
@@ -1,0 +1,7 @@
+import { Browser } from "puppeteer";
+
+const closeBrowser = async (browser: Browser) => {
+  await browser.close();
+};
+
+export default closeBrowser;

--- a/utils/fetch/fetchChapterPages.ts
+++ b/utils/fetch/fetchChapterPages.ts
@@ -2,8 +2,10 @@ import { Browser } from "puppeteer";
 import { FETCH_CHAPTER_PAGES_TAG } from "@/lib/cache-keys/unstable_cache";
 import { MAIN_URL } from "@/lib/constants";
 import { cache } from "react";
+import closeBrowser from "../closeBrowser";
 import initBrowser from "../initBrowser";
 import { unstable_cache } from "next/cache";
+
 let id = "";
 export const fetchChapterPages = cache((chapterSlug: string) => {
   id = `${chapterSlug}`;
@@ -42,7 +44,7 @@ export const fetchChapterPages = cache((chapterSlug: string) => {
           "main > section > div > div > button > span",
           (el) => el.textContent!,
         );
-        await browser.close();
+        await closeBrowser(browser);
         return { images: data, mangaSlug, currentChapterTitle };
       } catch (error) {
         console.error(error);

--- a/utils/fetch/fetchLatestUpdates.ts
+++ b/utils/fetch/fetchLatestUpdates.ts
@@ -3,6 +3,7 @@ import { FETCH_LATEST_UPDATES_TAG } from "@/lib/cache-keys/unstable_cache";
 import { LatestUpdateType } from "@/zod-schema/schema";
 import { MAIN_URL } from "@/lib/constants";
 import cleanUpMangaArray from "./clean-up-functions/cleanUpMangaArray";
+import closeBrowser from "../closeBrowser";
 import initBrowser from "../initBrowser";
 import { unstable_cache } from "next/cache";
 
@@ -56,7 +57,8 @@ export const fetchLatestUpdates = unstable_cache(
         };
         data.push(parsedObject);
       }
-      await browser.close();
+      await closeBrowser(browser);
+
       cleanUpMangaArray(data);
       return data;
     } catch (error) {

--- a/utils/fetch/fetchPopularManga.ts
+++ b/utils/fetch/fetchPopularManga.ts
@@ -4,6 +4,7 @@ import { MAIN_URL } from "@/lib/constants";
 import { PopularMangaType } from "@/zod-schema/schema";
 import { cache } from "react";
 import cleanUpMangaArray from "./clean-up-functions/cleanUpMangaArray";
+import closeBrowser from "../closeBrowser";
 import initBrowser from "../initBrowser";
 import { unstable_cache } from "next/cache";
 
@@ -79,7 +80,8 @@ export const fetchPopularManga = cache((numberOfManga: number) => {
           data.push(parsedData);
         }
 
-        await browser.close();
+        await closeBrowser(browser);
+
         cleanUpMangaArray(data);
         return data;
       } catch (error) {

--- a/utils/fetch/fetchSearchMangaResults.ts
+++ b/utils/fetch/fetchSearchMangaResults.ts
@@ -2,6 +2,7 @@ import { FETCH_SEARCH_MANGA_RESULTS_TAG } from "@/lib/cache-keys/unstable_cache"
 import { MAIN_URL } from "@/lib/constants";
 import { SearchResultMangaType } from "@/zod-schema/schema";
 import cleanUpMangaArray from "./clean-up-functions/cleanUpMangaArray";
+import closeBrowser from "../closeBrowser";
 import initBrowser from "../initBrowser";
 import sleep from "../sleep";
 import { unstable_cache } from "next/cache";
@@ -83,15 +84,13 @@ export const fetchSearchMangaResults = unstable_cache(
 
         data.push(parsedObject);
       }
+      await closeBrowser(browser);
 
       cleanUpMangaArray(data);
       return data;
     } catch (error) {
       console.error("Error in fetchSearchMangaResults:", error);
     } finally {
-      if (browser) {
-        await browser.close();
-      }
     }
   },
   [`${FETCH_SEARCH_MANGA_RESULTS_TAG}:${mangaEntered}`],

--- a/utils/fetch/fetchSearchMangaResults.ts
+++ b/utils/fetch/fetchSearchMangaResults.ts
@@ -38,9 +38,11 @@ export const fetchSearchMangaResults = unstable_cache(
         }
       } catch {}
 
-      const dataElements = await page.$$(
-        "main > div > section:nth-of-type(4) > article",
-      );
+      const dataElementsSelector =
+        "main > div > section:nth-of-type(4) > article";
+      await page.waitForSelector(dataElementsSelector, { timeout: 5000 });
+
+      const dataElements = await page.$$(dataElementsSelector);
 
       const data = await Promise.all(
         dataElements.slice(0, 60).map(async (element) => {
@@ -72,13 +74,13 @@ export const fetchSearchMangaResults = unstable_cache(
           };
         }),
       );
+
       await closeBrowser(browser);
 
       cleanUpMangaArray(data);
       return data;
-    } catch (error) {
-      console.error("Error in fetchSearchMangaResults:", error);
-      return null;
+    } catch {
+      return [];
     } finally {
     }
   },

--- a/utils/fetch/fetchSearchMangaResults.ts
+++ b/utils/fetch/fetchSearchMangaResults.ts
@@ -1,10 +1,8 @@
 import { FETCH_SEARCH_MANGA_RESULTS_TAG } from "@/lib/cache-keys/unstable_cache";
 import { MAIN_URL } from "@/lib/constants";
-import { SearchResultMangaType } from "@/zod-schema/schema";
 import cleanUpMangaArray from "./clean-up-functions/cleanUpMangaArray";
 import closeBrowser from "../closeBrowser";
 import initBrowser from "../initBrowser";
-import sleep from "../sleep";
 import { unstable_cache } from "next/cache";
 
 let mangaEntered = "";
@@ -24,72 +22,63 @@ export const fetchSearchMangaResults = unstable_cache(
       });
 
       page.setDefaultNavigationTimeout(2 * 60 * 1000);
+      await page.goto(`${MAIN_URL}/search?text=${manga}`, {
+        waitUntil: "domcontentloaded",
+        timeout: 0,
+      });
 
-      await page.goto(`${MAIN_URL}/search`);
-      const inputSelector =
-        "main > div > section:nth-of-type(2) > form > div > label > input:nth-of-type(2)";
-
-      await sleep(1000);
-      await page.focus(inputSelector);
-      await page.type(inputSelector, manga);
-      await page.keyboard.press("Enter");
-
-      await page.waitForSelector(
-        "main > div > section:nth-of-type(4) > article",
-      );
       const moreResultsButtonSelector =
         "main > div > section:nth-of-type(4) > button";
+
       try {
         const moreResultsButton = await page.$(moreResultsButtonSelector);
-        await sleep(1000);
 
         if (moreResultsButton) {
           await page.click("main > div > section:nth-of-type(4) > button");
         }
-        // eslint-disable-next-line no-unused-vars
-      } catch (error) {}
+      } catch {}
 
       const dataElements = await page.$$(
         "main > div > section:nth-of-type(4) > article",
       );
-      const data: SearchResultMangaType[] = [];
 
-      for (const element of dataElements.slice(0, 60)) {
-        const title = (await element.$eval(
-          "section:nth-of-type(2) > div > span > a",
-          (el) => el.textContent,
-        ))!;
-        const link = (await element.$eval("section > a", (el) =>
-          el.getAttribute("href"),
-        ))!;
+      const data = await Promise.all(
+        dataElements.slice(0, 60).map(async (element) => {
+          const title = (await element.$eval(
+            "section:nth-of-type(2) > div > span > a",
+            (el) => el.textContent,
+          ))!;
 
-        const mangaSlug = link.split("/").at(-2)!;
+          const link = (await element.$eval("section > a", (el) =>
+            el.getAttribute("href"),
+          ))!;
+          const mangaSlug = link.split("/").at(-2)!;
 
-        const image = await element.$eval(
-          "section > a > article > picture > img",
-          (el) => el.src,
-        );
+          const image = await element.$eval(
+            "section > a > article > picture > img",
+            (el) => el.src,
+          );
 
-        const yearOfRelease = (await element.$eval(
-          "section:nth-of-type(2) > div:nth-of-type(2) > span",
-          (el) => el.textContent,
-        ))!;
+          const yearOfRelease = (await element.$eval(
+            "section:nth-of-type(2) > div:nth-of-type(2) > span",
+            (el) => el.textContent,
+          ))!;
 
-        const parsedObject: SearchResultMangaType = {
-          title,
-          mangaSlug,
-          image,
-          yearOfRelease,
-        };
-
-        data.push(parsedObject);
-      }
+          return {
+            title,
+            mangaSlug,
+            image,
+            yearOfRelease,
+          };
+        }),
+      );
       await closeBrowser(browser);
 
       cleanUpMangaArray(data);
       return data;
     } catch (error) {
       console.error("Error in fetchSearchMangaResults:", error);
+      return null;
     } finally {
     }
   },

--- a/utils/fetch/fetchSearchMangaResults.ts
+++ b/utils/fetch/fetchSearchMangaResults.ts
@@ -10,10 +10,8 @@ let mangaEntered = "";
 export const fetchSearchMangaResults = unstable_cache(
   async (manga: string) => {
     mangaEntered = manga;
-    let browser;
+    let browser = await initBrowser();
     try {
-      browser = await initBrowser();
-
       const page = await browser.newPage();
 
       await page.setViewport({
@@ -75,13 +73,12 @@ export const fetchSearchMangaResults = unstable_cache(
         }),
       );
 
-      await closeBrowser(browser);
-
       cleanUpMangaArray(data);
       return data;
     } catch {
       return [];
     } finally {
+      await closeBrowser(browser);
     }
   },
   [`${FETCH_SEARCH_MANGA_RESULTS_TAG}:${mangaEntered}`],

--- a/utils/fetch/fetchUnitMangaInfo.ts
+++ b/utils/fetch/fetchUnitMangaInfo.ts
@@ -4,6 +4,7 @@ import { MAIN_URL } from "@/lib/constants";
 import { MangaUnitDataType } from "@/zod-schema/schema";
 import { cache } from "react";
 import cleanUpChaptersArray from "./clean-up-functions/cleanUpChaptersArray";
+import closeBrowser from "../closeBrowser";
 import initBrowser from "../initBrowser";
 import sleep from "../sleep";
 import { unstable_cache } from "next/cache";
@@ -139,6 +140,8 @@ export const fetchUnitMangaInfo = cache((mangaSlug: string) => {
             };
           }),
         );
+        await closeBrowser(browser);
+
         cleanUpChaptersArray(data.chapters);
         return data;
       } catch (error) {

--- a/utils/initBrowser.ts
+++ b/utils/initBrowser.ts
@@ -1,24 +1,28 @@
 import puppeteer from "puppeteer";
 
 const initBrowser = async () => {
-  const browser = await puppeteer.launch(
-    process.env.NODE_ENV === "development"
-      ? undefined
-      : {
-          headless: true,
-          executablePath: "/usr/bin/google-chrome-stable",
-          args: [
-            "--no-sandbox",
-            "--no-zygote",
-            "--disable-setuid-sandbox",
-            "--disable-dev-shm-usage",
-            "--disable-accelerated-2d-canvas",
-            "--disable-gpu",
-            "--disable-software-rasterizer",
-          ],
-        },
-  );
-  return browser;
+  const nodeEnv = process.env.NODE_ENV as string;
+  const isUsingBrowserless =
+    !!process.env.BROWSERLESS_URL && nodeEnv !== "build-local";
+
+  if (isUsingBrowserless) {
+    return await puppeteer.connect({
+      browserWSEndpoint: process.env.BROWSERLESS_URL,
+    });
+  }
+  return await puppeteer.launch({
+    executablePath: "/usr/bin/chromium",
+    headless: true,
+    args: [
+      "--no-sandbox",
+      "--no-zygote",
+      "--disable-setuid-sandbox",
+      "--disable-dev-shm-usage",
+      "--disable-accelerated-2d-canvas",
+      "--disable-gpu",
+      "--disable-software-rasterizer",
+    ],
+  });
 };
 
 export default initBrowser;

--- a/utils/initBrowser.ts
+++ b/utils/initBrowser.ts
@@ -1,15 +1,16 @@
 import puppeteer from "puppeteer";
 
 const initBrowser = async () => {
-  const nodeEnv = process.env.NODE_ENV as string;
+  const buildEnv = process.env.BUILD_ENV;
   const isUsingBrowserless =
-    !!process.env.BROWSERLESS_URL && nodeEnv !== "build-local";
+    !!process.env.BROWSERLESS_URL && buildEnv !== "build-local";
 
   if (isUsingBrowserless) {
     return await puppeteer.connect({
       browserWSEndpoint: process.env.BROWSERLESS_URL,
     });
   }
+
   return await puppeteer.launch({
     executablePath: "/usr/bin/chromium",
     headless: true,

--- a/utils/initBrowser.ts
+++ b/utils/initBrowser.ts
@@ -2,15 +2,25 @@ import puppeteer from "puppeteer";
 
 const initBrowser = async () => {
   const buildEnv = process.env.BUILD_ENV;
+  const isDev = process.env.NODE_ENV === "development";
   const isUsingBrowserless =
     !!process.env.BROWSERLESS_URL && buildEnv !== "build-local";
 
+  if (isDev) {
+    return puppeteer.launch({
+      args: ["--no-sandbox"],
+    });
+  }
+
+  // we use browserless in production (runtime)
   if (isUsingBrowserless) {
     return await puppeteer.connect({
       browserWSEndpoint: process.env.BROWSERLESS_URL,
     });
   }
 
+  // but we use chromium during build time in the Dockerfile, since
+  // browserless is not ready yet
   return await puppeteer.launch({
     executablePath: "/usr/bin/chromium",
     headless: true,


### PR DESCRIPTION
- switched to a docker-compose architecture with two services: the main app and the browserless chrome image
- passed the environment variables: SESSION_SECRET, UPLOADTHING_TOKEN, BROWSERLESS_URL to the application Dockerfile and installed chromium during the build time to properly generate he /popular and /home routes. Removed the line RUN npm install --omit=dev, reducing the docker image size of 44.5%
-  added more instructions to make puppeteer build use chromium during the build phase and use browserless at runtime
-  extracted the browser.close call at the end of scrapping functions for better reusability
- called the closeBrowser function in fetchUnitMangaInfo (wasn't called before, so it is fix)
-  added "debian-openssl-1.1.x" as possible target of prisma generate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for connecting to a remote browserless service for web scraping.
	- Introduced a utility to close browser instances more consistently.
- **Refactor**
	- Streamlined browser initialization and shutdown logic for improved reliability across different environments.
	- Simplified and optimized the search results fetching process for faster and more robust scraping.
	- Updated the Reload Data button to accept either a single tag or multiple tags, but not both.
- **Chores**
	- Updated Docker and Docker Compose configurations to use Chromium and browserless instead of Google Chrome and MongoDB.
	- Enhanced environment variable handling and Prisma client compatibility.
	- Bumped package version to 1.1.6.
- **Tests**
	- Improved test coverage for browser initialization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->