### PR TITLE
feat: multi-environment docker compose files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,8 @@ yarn-debug.log*
 yarn-error.log*
 
 # local env files
-.env*.local
-.env
+.env*
+
 # vercel
 .vercel
 

--- a/compose.db.yaml
+++ b/compose.db.yaml
@@ -1,0 +1,21 @@
+services:
+  # for test the build in local, in addition to the
+  # compose.yaml services
+  database:
+    image: prismagraphql/mongo-single-replica:4.4.3-bionic
+    container_name: mangaxr-db-test
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: password
+      INIT_WAIT_SEC: 3
+    volumes:
+      - mongo_data_test_full:/data/db
+    networks:
+      - manga-network
+
+volumes:
+  mongo_data_test_full:
+
+networks:
+  manga-network:
+    driver: bridge

--- a/compose.dev-services.yaml
+++ b/compose.dev-services.yaml
@@ -1,0 +1,72 @@
+services:
+  mongodb-primary:
+    image: bitnami/mongodb:latest
+    container_name: mongodb-primary
+    environment:
+      - MONGODB_REPLICA_SET_NAME=rs0
+      - MONGODB_ADVERTISED_HOSTNAME=mongodb-primary
+      - MONGODB_REPLICA_SET_MODE=primary
+      - MONGODB_ROOT_PASSWORD=password
+      - MONGODB_REPLICA_SET_KEY=replicasetkey123
+    ports:
+      - 27017:27017
+    volumes:
+      - mongodb_master_data:/bitnami
+    networks:
+      - manga-dev-network
+
+  mongodb-secondary:
+    image: bitnami/mongodb:latest
+    container_name: mongodb-secondary
+    depends_on:
+      - mongodb-primary
+    environment:
+      - MONGODB_REPLICA_SET_NAME=rs0
+      - MONGODB_ADVERTISED_HOSTNAME=mongodb-secondary
+      - MONGODB_REPLICA_SET_MODE=secondary
+      - MONGODB_INITIAL_PRIMARY_HOST=mongodb-primary
+      - MONGODB_INITIAL_PRIMARY_PORT_NUMBER=27017
+      - MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD=password
+      - MONGODB_REPLICA_SET_KEY=replicasetkey123
+    ports:
+      - 27027:27017
+    networks:
+      - manga-dev-network
+
+  mongodb-arbiter:
+    image: bitnami/mongodb:latest
+    container_name: mongodb-arbiter
+    depends_on:
+      - mongodb-primary
+    environment:
+      - MONGODB_REPLICA_SET_NAME=rs0
+      - MONGODB_ADVERTISED_HOSTNAME=mongodb-arbiter
+      - MONGODB_REPLICA_SET_MODE=arbiter
+      - MONGODB_INITIAL_PRIMARY_HOST=mongodb-primary
+      - MONGODB_INITIAL_PRIMARY_PORT_NUMBER=27017
+      - MONGODB_INITIAL_PRIMARY_ROOT_PASSWORD=password
+      - MONGODB_REPLICA_SET_KEY=replicasetkey123
+    ports:
+      - 27037:27017
+    networks:
+      - manga-dev-network
+
+  browserless_dev:
+    image: browserless/chrome
+    container_name: browserless-dev
+    ports:
+      - "127.0.0.1:3001:3000"
+    environment:
+      - DEFAULT_BLOCK_ADS=true
+      - MAX_CONCURRENT_SESSIONS=5
+      - PREBOOT_CHROME=true
+    networks:
+      - manga-dev-network
+
+volumes:
+  mongodb_master_data:
+    driver: local
+
+networks:
+  manga-dev-network:
+    driver: bridge

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,11 +1,8 @@
 services:
-  mangaxr-browserless:
+  app:
     build: .
     ports:
       - "127.0.0.1:3000:3000"
-    env_file:
-      - .env
-      - .env.local
     environment:
       - DATABASE_URL
       - SESSION_SECRET
@@ -13,7 +10,7 @@ services:
       - BROWSERLESS_URL
     depends_on:
       - browserless
-    container_name: manga-xr-browserless
+    container_name: manga-xr-app
     networks:
       - manga-network
 

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+docker compose -f compose.dev-services.yaml up -d
+
+cleanup() {
+  echo "Stopping dev services..."
+  docker compose -f compose.dev-services.yaml down
+}
+trap cleanup EXIT
+
+next dev --turbopack

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "manga-xr",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manga-xr",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",
         "@next/eslint-plugin-next": "^15.1.4",
         "@prisma/client": "^6.5.0",
         "@uploadthing/react": "^7.3.0",
         "bcrypt": "^5.1.1",
+        "dotenv-cli": "^8.0.0",
         "jose": "^5.9.6",
         "next": "^15.3.2",
         "next-themes": "^0.4.4",
@@ -4456,7 +4457,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -4765,6 +4765,42 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-cli": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-cli/-/dotenv-cli-8.0.0.tgz",
+      "integrity": "sha512-aLqYbK7xKOiTMIRf1lDPbI+Y+Ip/wo5k3eyp6ePysVaSqbyxjyK3dK35BTxG+rmd7djf5q2UPs4noPNH+cj0Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "dotenv": "^16.3.0",
+        "dotenv-expand": "^10.0.0",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "dotenv": "cli.js"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-10.0.0.tgz",
+      "integrity": "sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -7116,7 +7152,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -7717,7 +7752,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8944,7 +8978,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10301,7 +10334,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -10314,7 +10346,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12049,7 +12080,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -3,12 +3,13 @@
   "version": "1.1.6",
   "private": "false",
   "scripts": {
-    "dev": "next dev --turbopack",
+    "dev": "./dev.sh",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
     "test": "vitest",
-    "test:ui": "vitest --ui --coverage"
+    "test:ui": "vitest --ui --coverage",
+    "dev:studio": "dotenv -e .env.development npx prisma studio"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -16,6 +17,7 @@
     "@prisma/client": "^6.5.0",
     "@uploadthing/react": "^7.3.0",
     "bcrypt": "^5.1.1",
+    "dotenv-cli": "^8.0.0",
     "jose": "^5.9.6",
     "next": "^15.3.2",
     "next-themes": "^0.4.4",

--- a/tests/utils/initBrowser.test.ts
+++ b/tests/utils/initBrowser.test.ts
@@ -18,13 +18,14 @@ describe("initBrowser", () => {
     vi.unstubAllEnvs();
   });
 
-  it("should connect to the local browser in development", async () => {
+  it("should launch browser with default browserWSEndpoint in development", async () => {
     vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("BROWSERLESS_URL", "ws://localhost:3001");
 
     await initBrowser();
 
-    expect(mockLaunch).toHaveBeenCalledWith({
-      args: ["--no-sandbox"],
+    expect(mockConnect).toHaveBeenCalledWith({
+      browserWSEndpoint: "ws://localhost:3001",
     });
   });
 

--- a/utils/initBrowser.ts
+++ b/utils/initBrowser.ts
@@ -6,13 +6,14 @@ const initBrowser = async () => {
   const isUsingBrowserless =
     !!process.env.BROWSERLESS_URL && buildEnv !== "build-local";
 
+  // we use browserless in development
   if (isDev) {
-    return puppeteer.launch({
-      args: ["--no-sandbox"],
+    return await puppeteer.connect({
+      browserWSEndpoint: process.env.BROWSERLESS_URL,
     });
   }
 
-  // we use browserless in production (runtime)
+  // we also use browserless in production (runtime)
   if (isUsingBrowserless) {
     return await puppeteer.connect({
       browserWSEndpoint: process.env.BROWSERLESS_URL,


### PR DESCRIPTION
- added compose.dev-services.yaml (the app will now use browserless and a mongodb replica set in development, in conjunction with "npm run dev")
- added the compose.db.yaml file that will be used for testing (in conjunction with the compose.yaml file): three services to test the app: the app service, browserless and a mongodb replica set
- updated the tests to satisfy the new development requirements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Docker Compose configurations for running MongoDB replica sets and a browserless Chrome service for development.
  - Introduced a script to automate starting and stopping development services and launching the development server.
  - Added a script to launch Prisma Studio with environment variables from a specific file.

- **Chores**
  - Updated the ignore pattern for environment files to simplify configuration.
  - Changed service and container names in Docker Compose for clarity.
  - Updated development scripts to use the new automation script and added a dependency for environment variable management.

- **Bug Fixes**
  - Improved test and browser initialization logic to connect to a remote browser instance in development, ensuring compatibility with the new browserless service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->