### PR TITLE
feat: vpn x 2 and chore: new domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ next-env.d.ts
 
 # vscode
 .vscode
+
+#vpn
+vpn-config.txt

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ next-env.d.ts
 
 # vscode
 .vscode
+
+#vpn
+*.ovpn
+credentials.txt

--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,3 @@ next-env.d.ts
 
 # vscode
 .vscode
-
-#vpn
-*.ovpn
-credentials.txt

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <h1 align="center">Manga XR</h1>
 <p align="center">The platform to read manga endlessly.<br/>
-<a href="https://mangaxr.glacifer.com/">mangaxr.glacifer.com</a>
+<a href="https://mangaxr.app/">mangaxr.app</a>
 </p>
 
 <p align="center">
@@ -34,8 +34,8 @@
 - [Running Locally](#running-locally)
   - [Installation](#installation)
   - [.env files](#env-files)
-     - [.env.development](#envdevelopment)
-     - [.env.staging](#envstaging)
+    - [.env.development](#envdevelopment)
+    - [.env.staging](#envstaging)
 - [Progress list](#progress-list)
 - [Contributing](#contributing)
 - [License](#license)
@@ -82,6 +82,7 @@ For the `DATABASE_URL`, use
 ```bash
 DATABASE_URL="mongodb://root:password@localhost:27017/mangaxr-dev?replicaSet=rs0&authSource=admin"
 ```
+
 (Local replica set for Prisma transactions, this is a docker volume, so the data will be stored locally)
 
 [compose.yaml](/docker/development/compose.yaml)
@@ -97,6 +98,7 @@ Then create an accout on [Uploadthing](https://uploadthing.com/). Then get your 
 ```bash
 UPLOADTHING_TOKEN=...
 ```
+
 At the end the `.env.development` file should look to something like:
 
 ```bash
@@ -111,12 +113,14 @@ Then serve locally:
 ```bash
 npm run dev
 ```
-You also need the compose services for development. There are the browserless-dev service and a Mongo DB replica set, which is a docker volume required for prisma to run the transactions locally. To do so: 
+
+You also need the compose services for development. There are the browserless-dev service and a Mongo DB replica set, which is a docker volume required for prisma to run the transactions locally. To do so:
 
 ```bash
 make dev-up # to start the services
 make dev-down # to stop them
 ```
+
 For more information about the commands available, check the [Makefile](/Makefile)
 
 Prisma Studio to explore and manipulate the data:
@@ -132,6 +136,7 @@ npm run test:ui
 ```
 
 #### .env.staging
+
 The services in the [staging compose.yaml](/docker/staging/compose.yaml) allow you to create a staging version on the application with three docker compose services: the app itself, a browserless instance and a MongoDB replica set for Prisma transactions.
 
 Create a `.env.staging` file in the root of the directory with the variables `DATABASE_URL`,`SESSION_SECRET`, `BROWSERLESS_URL` and `UPLOADTHING_TOKEN`.
@@ -150,13 +155,15 @@ DATABASE_URL="mongodb://root:password@mongodb-primary:27017/mangaxr_db_staging?r
 ```
 
 For the `SESSION_SECRET` and `UPLOADTHING_TOKEN`, you can follow the same steps as in the [.env.development](#envdevelopment)
-And for `BROWSERLESS_URL`, use: 
+And for `BROWSERLESS_URL`, use:
 
 ```bash
 ws://browserless:3000
 ```
+
 (the name of the compose service in the docker network)
-At the end, the `.env.staging` should look to something like: 
+At the end, the `.env.staging` should look to something like:
+
 ```bash
 DATABASE_URL="mongodb://root:password@mongodb-primary:27017/mangaxr_db_staging?replicaSet=rs0&authSource=admin"
 SESSION_SECRET="SHA256:..."
@@ -164,7 +171,7 @@ BROWSERLESS_URL="ws://browserless:3000"
 UPLOADTHING_TOKEN=...
 ```
 
-Then to open the staging version of the application: 
+Then to open the staging version of the application:
 
 ```bash
 make staging-up # to start the services

--- a/README.md
+++ b/README.md
@@ -158,17 +158,25 @@ For the `SESSION_SECRET` and `UPLOADTHING_TOKEN`, you can follow the same steps 
 And for `BROWSERLESS_URL`, use:
 
 ```bash
-ws://browserless:3000
+ws://caddy:3000
 ```
 
 (the name of the compose service in the docker network)
+
+You also need a `WIREGUARD_PRIVATE_KEY` and `PROTONVPN_SERVER`. Both of them can be obtained by creating a free proton vpn account and generating a wireguard configuration.
+
 At the end, the `.env.staging` should look to something like:
 
 ```bash
 DATABASE_URL="mongodb://root:password@mongodb-primary:27017/mangaxr_db_staging?replicaSet=rs0&authSource=admin"
 SESSION_SECRET="SHA256:..."
-BROWSERLESS_URL="ws://browserless:3000"
+BROWSERLESS_URL="ws://caddy:3000"
 UPLOADTHING_TOKEN=...
+WIREGUARD_PRIVATE_KEY=...
+PROTONVPN_SERVER=...
+IPCHECK_INTERVAL="0"
+PROTONVPN_KILLSWITCH="false"
+
 ```
 
 Then to open the staging version of the application:

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -11,7 +11,7 @@ import { Toaster } from "react-hot-toast";
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://mangaxr.glacifer.com/"),
+  metadataBase: new URL("https://mangaxr.app/"),
   title: "MangaXR",
   description: "MangaXR is a platform to read manga for free, endlessly",
   openGraph: {

--- a/docker/production/Caddyfile
+++ b/docker/production/Caddyfile
@@ -1,0 +1,3 @@
+:3000 {
+    reverse_proxy protonvpn:3000
+}

--- a/docker/production/compose.yaml
+++ b/docker/production/compose.yaml
@@ -11,6 +11,30 @@ services:
     networks:
       - manga-network
 
+  protonvpn:
+    image: ghcr.io/tprasadtp/protonwire:latest
+    container_name: protonvpn
+    restart: unless-stopped
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun
+    env_file:
+      - ../../.env.production
+    sysctls:
+      net.ipv4.conf.all.rp_filter: 2
+      net.ipv6.conf.all.disable_ipv6: 1
+    volumes:
+      - type: tmpfs
+        target: /tmp
+      - type: bind
+        source: private.key
+        target: /etc/protonwire/private-key
+        read_only: true
+    tty: true
+    networks:
+      - vpn-network
+
   browserless:
     image: ghcr.io/browserless/chromium:latest
     environment:
@@ -18,9 +42,19 @@ services:
       - MAX_CONCURRENT_SESSIONS=5
       - PREBOOT_CHROME=true
     container_name: browserless
+    network_mode: "service:protonvpn" 
+
+  caddy:
+    image: caddy:latest
+    container_name: caddy-proxy
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
     networks:
-      - manga-network
+      vpn-network: {}
+      manga-network: {}
 
 networks:
+  vpn-network:
+    driver: bridge
   manga-network:
     driver: bridge

--- a/docker/staging/Caddyfile
+++ b/docker/staging/Caddyfile
@@ -1,0 +1,3 @@
+:3000 {
+    reverse_proxy protonvpn:3000
+}

--- a/docker/staging/compose.yaml
+++ b/docker/staging/compose.yaml
@@ -20,29 +20,29 @@ services:
         target: /etc/protonwire/private-key
         read_only: true
     tty: true
-
+    networks:
+      - vpn-network
+ 
   browserless:
     image: ghcr.io/browserless/chromium:latest
     container_name: browserless
-    network_mode: "service:protonvpn"
     environment:
       - DEFAULT_BLOCK_ADS=true
       - MAX_CONCURRENT_SESSIONS=5
       - PREBOOT_CHROME=true
-
+    network_mode: "service:protonvpn" 
+ 
   caddy:
     image: caddy:latest
     container_name: caddy-proxy
-    network_mode: "service:protonvpn"
-    command: >
-      caddy reverse-proxy
-      --from :3000
-      --to http://127.0.0.1:3000
-      --header-up Host {host}
-      --header-up Upgrade {>Upgrade}
-      --header-up Connection {>Connection}
-    tty: true
-
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+    networks:
+      vpn-network: {}
+      manga-network: {}
+    ports:
+      - "127.0.0.1:3001:3000"
+ 
   app:
     build:
       context: ../../
@@ -55,8 +55,8 @@ services:
     networks:
       - manga-network
     ports:
-      - "4000:3000"
-
+      - "127.0.0.1:3000:3000"
+ 
   mongodb-primary:
     image: bitnami/mongodb:latest
     container_name: mongodb-primary
@@ -72,7 +72,7 @@ services:
       - manga-xr-staging-db:/bitnami
     networks:
       - manga-network
-
+ 
   mongodb-secondary:
     image: bitnami/mongodb:latest
     container_name: mongodb-secondary
@@ -90,7 +90,7 @@ services:
       - "127.0.0.1:27027:27017"
     networks:
       - manga-network
-
+ 
   mongodb-arbiter:
     image: bitnami/mongodb:latest
     container_name: mongodb-arbiter
@@ -114,5 +114,7 @@ volumes:
     driver: local
 
 networks:
+  vpn-network:
+    driver: bridge
   manga-network:
     driver: bridge

--- a/docker/staging/compose.yaml
+++ b/docker/staging/compose.yaml
@@ -1,29 +1,61 @@
 services:
-  app:
-    build:
-      context: ../../
-      dockerfile: docker/staging/Dockerfile
-    ports:
-      - "127.0.0.1:3000:3000"
+  protonvpn:
+    image: ghcr.io/tprasadtp/protonwire:latest
+    container_name: protonvpn
+    restart: unless-stopped
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun
     env_file:
       - ../../.env.staging
-    depends_on:
-      - browserless
-    container_name: manga-xr-app
-    networks:
-      - manga-network
+    sysctls:
+      net.ipv4.conf.all.rp_filter: 2
+      net.ipv6.conf.all.disable_ipv6: 1
+    volumes:
+      - type: tmpfs
+        target: /tmp
+      - type: bind
+        source: private.key
+        target: /etc/protonwire/private-key
+        read_only: true
+    tty: true
 
   browserless:
     image: ghcr.io/browserless/chromium:latest
-    ports:
-      - "127.0.0.1:3001:3000"
+    container_name: browserless
+    network_mode: "service:protonvpn"
     environment:
       - DEFAULT_BLOCK_ADS=true
       - MAX_CONCURRENT_SESSIONS=5
       - PREBOOT_CHROME=true
-    container_name: browserless
+
+  caddy:
+    image: caddy:latest
+    container_name: caddy-proxy
+    network_mode: "service:protonvpn"
+    command: >
+      caddy reverse-proxy
+      --from :3000
+      --to http://127.0.0.1:3000
+      --header-up Host {host}
+      --header-up Upgrade {>Upgrade}
+      --header-up Connection {>Connection}
+    tty: true
+
+  app:
+    build:
+      context: ../../
+      dockerfile: docker/staging/Dockerfile
+    container_name: manga-xr-app
+    env_file:
+      - ../../.env.staging
+    depends_on:
+      - caddy
     networks:
       - manga-network
+    ports:
+      - "4000:3000"
 
   mongodb-primary:
     image: bitnami/mongodb:latest

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manga-xr",
-  "version": "1.2",
+  "version": "1.2.2",
   "private": "false",
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Commits 

- [feat: vpn](https://github.com/Friedrich482/manga-xr/commit/ed8192e2aadffe5861dea16d14044676e8629e13)
	- added a new vpn service to proxy and mask all request from browserless through it
	
- [feat: vpn](https://github.com/Friedrich482/manga-xr/commit/2ebe0a6ce4a656b12679a10375d0aeb406ef93aa)
	- properly wired up the vpn and the browserless instance
	- the traffic coming from the browserless instance is routed through the vpn gateway and this masks the address of the browserless instance
	- the app communicates with browserless through a caddy container that is in both networks and plays the role of proxy between app and browserless

- [chore: new domain](https://github.com/Friedrich482/manga-xr/commit/193c99d41eba19f5fbaf1fd0197f76e9f79abcbd)
	- migrated the app to https://mangaxr.app/
	- updated the README and the metadataBase in the metadata object to reflect that change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - VPN-backed networking added for staging/production to improve privacy and access reliability.
  - Reverse-proxy layer introduced to stabilize app access.

- Documentation
  - README updated with new primary domain (mangaxr.app), environment guidance, and staging/dev instructions.

- Chores
  - App metadata updated to use mangaxr.app.
  - Deployment configurations added for VPN, proxy, and segmented networks.
  - Local VPN config file added to ignore list; package version bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->